### PR TITLE
fix: solid-shell crash

### DIFF
--- a/solid-shell/package.json
+++ b/solid-shell/package.json
@@ -23,7 +23,7 @@
     "vite-plugin-solid": "^2.5.0"
   },
   "dependencies": {
-    "@solidjs/router": "^0.6.0",
+    "@solidjs/router": "^0.8.2",
     "solid-element": "^1.6.3",
     "solid-js": "^1.6.6"
   }


### PR DESCRIPTION
"@solidjs/router": "^0.6.0" makes `solid-shell` crash and throws this error.
```
Uncaught TypeError: c.outlet is not a function
```
![image](https://user-images.githubusercontent.com/48156618/230304362-6d974c3e-6d69-4e0a-8794-984b0dadae71.png)

A new version of `@solidjs/router` has fixed this error.

@quangnv13 please checkout this pull request ^^